### PR TITLE
Style nav bar and links

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,10 @@
 @import 'tailwindcss';
 
 @layer components {
+  .nav-link {
+    @apply flex items-center text-white text-right font-light text-base leading-[28.8px] whitespace-nowrap px-0 py-[1.6px];
+  }
+
   .btn {
     @apply inline-block rounded border border-black px-4 py-2 text-sm transition-colors duration-200 hover:bg-black hover:text-white;
   }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,9 @@
 import './globals.css'
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import { Poppins } from 'next/font/google'
+
+const poppins = Poppins({ subsets: ['latin'], weight: ['300'] })
 
 export const metadata: Metadata = {
   title: 'Michael Zick | Peak Performance Coach',
@@ -10,17 +13,23 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="min-h-screen flex flex-col">
-        <header className="fixed top-0 left-0 right-0 bg-white/90 backdrop-blur z-50">
-          <nav className="max-w-screen-xl mx-auto flex items-center justify-between p-4">
-            <Link href="/" className="font-medium">Michael Zick</Link>
+      <body className={`${poppins.className} min-h-screen flex flex-col`}>
+        <header className="fixed top-0 w-full z-50 px-[70px] bg-transparent">
+          <nav className="flex w-full items-center justify-between py-4 text-white">
+            <Link href="/" className="nav-link text-[32px]">Michael Zick</Link>
             <div className="hidden md:flex space-x-6">
-              <Link href="/work-with-me">Work With Me</Link>
-              <Link href="/about">About</Link>
-              <Link href="/testimonials">Testimonials</Link>
-              <Link href="/contact">Contact</Link>
+              <Link href="/work-with-me" className="nav-link">Work With Me</Link>
+              <Link href="/about" className="nav-link">About</Link>
+              <Link href="/testimonials" className="nav-link">Testimonials</Link>
+              <Link href="/contact" className="nav-link">Contact</Link>
             </div>
-            <a href="https://www.zickonezero.com/" className="btn" target="_blank">Product Management</a>
+            <a
+              href="https://www.zickonezero.com/"
+              className="btn nav-link border-white"
+              target="_blank"
+            >
+              Product Management
+            </a>
           </nav>
         </header>
         <main className="flex-1 pt-20">{children}</main>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -32,7 +32,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             </a>
           </nav>
         </header>
-        <main className="flex-1 pt-20">{children}</main>
+        <main className="flex-1">{children}</main>
         <footer className="bg-black text-white py-8">
           <div className="max-w-screen-xl mx-auto text-center space-y-4 text-sm">
             <p>Michael Zick Coaching | Peak Performance Coach</p>


### PR DESCRIPTION
## Summary
- Make header fixed, transparent and full-width with 70px padding
- Style nav links with flex layout, Poppins font, and 32px site title

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6895ec59b3408320b67b399be0c68b17