### PR TITLE
Use Squarespace HTML content for About page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,8 +1,113 @@
 export default function About() {
   return (
-    <div className="max-w-3xl mx-auto py-24 space-y-4">
-      <h1 className="text-3xl font-semibold">About</h1>
-      <p>This page is a placeholder for information about Michael Zick.</p>
+    <div className="flex flex-col">
+      <section className="bg-[var(--dark-blue)] text-white px-6 md:px-8 pt-40 md:pt-56 pb-24 md:pb-32">
+        <div className="max-w-screen-xl mx-auto">
+          <h1 className="text-[64px] font-semibold mb-6">About</h1>
+          <h3 className="text-[35px] font-light">
+            “Mental health is a commitment to reality at all costs.” — M. Scott Peck
+          </h3>
+        </div>
+      </section>
+
+      <section className="px-6 md:px-8 py-24 md:py-32">
+        <div className="max-w-screen-xl mx-auto">
+          <div className="flex flex-col md:flex-row md:items-center gap-8">
+            <div className="md:w-1/2 space-y-6 order-2 md:order-1">
+              <h2 className="text-[45px] font-semibold">Michael is all about action.</h2>
+              <p className="text-[23px]">
+                He stands by the phrase, "We don't think our way into right action; we act our
+                way into right thinking." In other words, replacing worrying with doing is the
+                path to success that Michael encourages, and his clients have the results to show
+                for it.
+              </p>
+              <p className="text-[23px]">
+                He has worked with the best of the best — from top business and marketing
+                coaches to world-renowned relationship experts like Dr. Glover and Erwan and
+                Alicia Davon.
+              </p>
+              <p className="text-[23px]">
+                With his no-BS approach, those who work with Michael will know what it's like to
+                replace rumination with action, take ownership of their thoughts, feelings, and
+                behaviors, stop being a victim, and play well with others without being "nice."
+              </p>
+            </div>
+            <div className="md:w-1/2 order-1 md:order-2">
+              <img
+                src="https://images.squarespace-cdn.com/content/v1/5f13a142b2a20e01e9bfd9e3/c328a4db-a4b7-436d-ba24-1222051310e5/DSC03651.jpg"
+                alt="Michael wearing a jacket"
+                className="w-full h-auto object-cover"
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="px-6 md:px-8 py-24 md:py-32">
+        <div className="max-w-screen-xl mx-auto">
+          <div className="flex flex-col md:flex-row md:items-center gap-8">
+            <div className="md:w-1/2">
+              <img
+                src="https://images.squarespace-cdn.com/content/v1/5f13a142b2a20e01e9bfd9e3/1633647108612-3VE4IJDM88VBYCF0MVKR/MichaelSuitHotel%2522Driplinell%2522-0333.jpg"
+                alt="Michael in suit"
+                className="w-full h-auto object-cover"
+              />
+            </div>
+            <div className="md:w-1/2 space-y-6">
+              <p className="text-[23px]">
+                Michael has successfully coached celebrities, entrepreneurs, Nice Guys, and men
+                and women through various transitions. Is it time for your life to change for the
+                better?
+              </p>
+              <h2 className="text-[45px] font-semibold">Let’s talk.</h2>
+              <a
+                href="https://link.michaelzick.com/45min"
+                target="_blank"
+                className="btn inline-block"
+              >
+                Book a Free 45-Minute Strategy Session
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="px-6 md:px-8 py-24 md:py-32">
+        <div className="max-w-screen-xl mx-auto">
+          <div className="grid md:grid-cols-2 gap-12 items-start">
+            <div className="space-y-4">
+              <h3 className="text-[35px] font-medium">
+                Certified as a Life &amp; Relationship Coach by Life Purpose Institute.
+              </h3>
+              <h3 className="text-[35px] font-medium">
+                Certified by Dr. Robert Glover, author of “No More Mr. Nice Guy” and renowned
+                therapist.
+              </h3>
+              <h3 className="text-[35px] font-medium">
+                Established in the Los Angeles mental health and recovery community since 2015.
+              </h3>
+              <a
+                href="https://link.michaelzick.com/45min"
+                target="_blank"
+                className="btn inline-block mt-6"
+              >
+                Book a Free 45-Minute Strategy Session
+              </a>
+            </div>
+            <div className="space-y-4">
+              <h2 className="text-[45px] font-semibold">Specialties:</h2>
+              <ul className="list-disc pl-6 space-y-2 text-[23px]">
+                <li>Nice Guy Syndrome</li>
+                <li>Relationships &amp; dating</li>
+                <li>Finding your purpose</li>
+                <li>Codependency</li>
+                <li>Belief reprogramming</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
     </div>
   )
 }
+


### PR DESCRIPTION
## Summary
- Rebuilt About page with hero, biography, and call-to-action sections, formatted like Work With Me page
- Highlight certifications and specialties with clear bullet layout

## Testing
- `npm test`
- `npm run lint` *(prompts for configuration, no lint results)*

------
https://chatgpt.com/codex/tasks/task_e_6896751e9974832087caf287d0b7c279