### PR TITLE
feat: apply primary blue styling to buttons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,6 +5,7 @@
   --default-grey: #38383b;
   --light-grey: #dfe0e1;
   --white: #ffffff;
+  --primary-blue: #0071e3;
 }
 
 body, html {
@@ -68,6 +69,6 @@ body, html {
   }
 
   .btn {
-    @apply inline-block rounded border border-black px-4 py-2 text-sm transition-colors duration-200 hover:bg-black hover:text-white;
+    @apply inline-block rounded bg-primary-blue text-white px-[42px] py-[30px] text-[16px] transition-colors duration-200 hover:opacity-90;
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,6 +9,9 @@ module.exports = {
       fontFamily: {
         sans: ['"Helvetica Neue"', 'Helvetica', 'Arial', 'sans-serif'],
       },
+      colors: {
+        'primary-blue': 'var(--primary-blue)',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- add `primary-blue` color variable and Tailwind color
- style `.btn` with new color and 42px/30px padding

## Testing
- `npm test`
- `npm run lint` *(fails: fetch failed, ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6896def1eca48320b5b8e77252a94d7a