### PR TITLE
Add SEO metadata to site pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,3 +1,32 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Michael Zick | About',
+  description:
+    'Learn more about Michael Zick, a Los Angeles-based peak performance coach dedicated to helping clients take action and build powerful relationships.',
+  openGraph: {
+    title: 'Michael Zick | About',
+    description:
+      'Learn more about Michael Zick, a Los Angeles-based peak performance coach dedicated to helping clients take action and build powerful relationships.',
+    url: 'https://michaelzick.com/about',
+    siteName: 'Michael Zick',
+    images: [
+      {
+        url: 'https://michaelzick.com/img/dark_mountains_2500.webp',
+        alt: 'Dark mountain landscape',
+      },
+    ],
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Michael Zick | About',
+    description:
+      'Learn more about Michael Zick, a Los Angeles-based peak performance coach dedicated to helping clients take action and build powerful relationships.',
+    images: ['https://michaelzick.com/img/dark_mountains_2500.webp'],
+  },
+}
+
 export default function About() {
   return (
     <div className="flex flex-col">

--- a/app/contact/ContactContent.tsx
+++ b/app/contact/ContactContent.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect } from 'react';
+import { initMail64 } from '../../lib/mail64';
+
+export default function ContactContent() {
+  useEffect(() => {
+    initMail64();
+  }, []);
+
+  return (
+    <div className="flex flex-col">
+      <section
+        className="bg-default-grey text-white px-6 md:px-8 pt-40 md:pt-56 pb-24 md:pb-32"
+        style={{
+          backgroundImage: "url('/img/lake_reflection_2500.webp')",
+        }}
+      >
+        <div className="max-w-[1400px] mx-auto grid md:grid-cols-12 gap-8">
+          <div className="md:col-span-5 space-y-6">
+            <h1 className="text-[64px] font-semibold">Contact</h1>
+            <a className="btn js-mail64" data-addr="Znc5bzVnNzJAYW5vbmFkZHkuY29t">
+              Email Me
+            </a>
+            <h2 className="text-2xl font-semibold">Socials</h2>
+            <div className="flex space-x-4">
+              <a
+                href="https://michaelzick.medium.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Medium"
+              >
+                <svg
+                  className="w-11 h-11 fill-current"
+                  viewBox="0 0 64 64"
+                  aria-hidden="true"
+                >
+                  <path d="M46.908,23.95c-0.006-0.005-0.011-0.01-0.018-0.014l-0.01-0.005l-9.05-4.525c-0.061-0.031-0.125-0.051-0.19-0.068c-0.082-0.021-0.165-0.034-0.249-0.034c-0.347,0-0.692,0.174-0.878,0.477l-5.21,8.467l6.538,10.625l9.095-14.779C46.966,24.046,46.952,23.985,46.908,23.95z M28.433,35.958L37,40.241L28.433,26.32V35.958z M38.287,40.884l7.052,3.526C46.256,44.869,47,44.548,47,43.693V26.726L38.287,40.884z M26.946,23.964l-8.839-4.419c-0.16-0.08-0.312-0.118-0.449-0.118c-0.387,0-0.659,0.299-0.659,0.802v19.083c0,0.511,0.374,1.116,0.831,1.344l7.785,3.892c0.2,0.1,0.39,0.147,0.561,0.147c0.484,0,0.823-0.374,0.823-1.003V24.051C27,24.014,26.979,23.98,26.946,23.964z" />
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,51 +1,34 @@
-"use client";
+import type { Metadata } from 'next';
+import ContactContent from './ContactContent';
 
-import { useEffect } from 'react';
-import { initMail64 } from '../../lib/mail64';
+export const metadata: Metadata = {
+  title: 'Michael Zick | Contact',
+  description:
+    'Get in touch with Michael Zick for coaching inquiries and strategy sessions.',
+  openGraph: {
+    title: 'Michael Zick | Contact',
+    description:
+      'Get in touch with Michael Zick for coaching inquiries and strategy sessions.',
+    url: 'https://michaelzick.com/contact',
+    siteName: 'Michael Zick',
+    images: [
+      {
+        url: 'https://michaelzick.com/img/lake_reflection_2500.webp',
+        alt: 'Lake reflection at dusk',
+      },
+    ],
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Michael Zick | Contact',
+    description:
+      'Get in touch with Michael Zick for coaching inquiries and strategy sessions.',
+    images: ['https://michaelzick.com/img/lake_reflection_2500.webp'],
+  },
+};
 
 export default function Contact() {
-  useEffect(() => {
-    initMail64();
-  }, []);
-
-  return (
-    <div className="flex flex-col">
-      <section className="bg-default-grey text-white px-6 md:px-8 pt-40 md:pt-56 pb-24 md:pb-32"
-        style={{
-          backgroundImage:
-            "url('/img/lake_reflection_2500.webp')",
-        }}
-      >
-        <div className="max-w-[1400px] mx-auto grid md:grid-cols-12 gap-8">
-          <div className="md:col-span-5 space-y-6">
-            <h1 className="text-[64px] font-semibold">Contact</h1>
-            <a
-              className="btn js-mail64"
-              data-addr="Znc5bzVnNzJAYW5vbmFkZHkuY29t"
-            >
-              Email Me
-            </a>
-            <h2 className="text-2xl font-semibold">Socials</h2>
-            <div className="flex space-x-4">
-              <a
-                href="https://michaelzick.medium.com"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Medium"
-              >
-                <svg
-                  className="w-11 h-11 fill-current"
-                  viewBox="0 0 64 64"
-                  aria-hidden="true"
-                >
-                  <path d="M46.908,23.95c-0.006-0.005-0.011-0.01-0.018-0.014l-0.01-0.005l-9.05-4.525c-0.061-0.031-0.125-0.051-0.19-0.068c-0.082-0.021-0.165-0.034-0.249-0.034c-0.347,0-0.692,0.174-0.878,0.477l-5.21,8.467l6.538,10.625l9.095-14.779C46.966,24.046,46.952,23.985,46.908,23.95z M28.433,35.958L37,40.241L28.433,26.32V35.958z M38.287,40.884l7.052,3.526C46.256,44.869,47,44.548,47,43.693V26.726L38.287,40.884z M26.946,23.964l-8.839-4.419c-0.16-0.08-0.312-0.118-0.449-0.118c-0.387,0-0.659,0.299-0.659,0.802v19.083c0,0.511,0.374,1.116,0.831,1.344l7.785,3.892c0.2,0.1,0.39,0.147,0.561,0.147c0.484,0,0.823-0.374,0.823-1.003V24.051C27,24.014,26.979,23.98,26.946,23.964z" />
-                </svg>
-              </a>
-            </div>
-          </div>
-        </div>
-      </section>
-    </div>
-  );
+  return <ContactContent />;
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,22 @@ import NavBar from '../components/NavBar'
 
 export const metadata: Metadata = {
   title: 'Michael Zick | Peak Performance Coach',
-  description: "I'm a Los Angeles-based certified life and relationship coach, helping individuals level up and relate powerfully.",
+  description:
+    'Los Angeles-based peak performance coach helping individuals take action, overcome limiting beliefs, and build powerful relationships.',
+  openGraph: {
+    title: 'Michael Zick | Peak Performance Coach',
+    description:
+      'Los Angeles-based peak performance coach helping individuals take action, overcome limiting beliefs, and build powerful relationships.',
+    url: 'https://michaelzick.com',
+    siteName: 'Michael Zick',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Michael Zick | Peak Performance Coach',
+    description:
+      'Los Angeles-based peak performance coach helping individuals take action, overcome limiting beliefs, and build powerful relationships.',
+  },
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,35 @@
 import Image from 'next/image'
 import Link from 'next/link'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Michael Zick | Peak Performance Coach',
+  description:
+    'Los Angeles-based peak performance coach helping individuals take action, overcome limiting beliefs, and build powerful relationships.',
+  openGraph: {
+    title: 'Michael Zick | Peak Performance Coach',
+    description:
+      'Los Angeles-based peak performance coach helping individuals take action, overcome limiting beliefs, and build powerful relationships.',
+    url: 'https://michaelzick.com',
+    siteName: 'Michael Zick',
+    images: [
+      {
+        url: 'https://images.squarespace-cdn.com/content/v1/5f13a142b2a20e01e9bfd9e3/1653791669541-TDDSOVCWEKVZYEX6T108/unsplash-image-CeYGSLBtuWk.jpg',
+        alt: 'Mountain landscape at sunset',
+      },
+    ],
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Michael Zick | Peak Performance Coach',
+    description:
+      'Los Angeles-based peak performance coach helping individuals take action, overcome limiting beliefs, and build powerful relationships.',
+    images: [
+      'https://images.squarespace-cdn.com/content/v1/5f13a142b2a20e01e9bfd9e3/1653791669541-TDDSOVCWEKVZYEX6T108/unsplash-image-CeYGSLBtuWk.jpg',
+    ],
+  },
+}
 
 export default function Home() {
   return (

--- a/app/testimonials/page.tsx
+++ b/app/testimonials/page.tsx
@@ -1,3 +1,32 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Michael Zick | Testimonials',
+  description:
+    'Hear from clients who have transformed their lives through coaching with Michael Zick.',
+  openGraph: {
+    title: 'Michael Zick | Testimonials',
+    description:
+      'Hear from clients who have transformed their lives through coaching with Michael Zick.',
+    url: 'https://michaelzick.com/testimonials',
+    siteName: 'Michael Zick',
+    images: [
+      {
+        url: 'https://michaelzick.com/img/mountains_2500.webp',
+        alt: 'Mountain range at sunrise',
+      },
+    ],
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Michael Zick | Testimonials',
+    description:
+      'Hear from clients who have transformed their lives through coaching with Michael Zick.',
+    images: ['https://michaelzick.com/img/mountains_2500.webp'],
+  },
+}
+
 export default function Testimonials() {
   return (
     <div className="flex flex-col">

--- a/app/work-with-me/page.tsx
+++ b/app/work-with-me/page.tsx
@@ -1,3 +1,32 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Michael Zick | Work With Me',
+  description:
+    'Explore coaching programs with Michael Zick to achieve peak performance and lasting change.',
+  openGraph: {
+    title: 'Michael Zick | Work With Me',
+    description:
+      'Explore coaching programs with Michael Zick to achieve peak performance and lasting change.',
+    url: 'https://michaelzick.com/work-with-me',
+    siteName: 'Michael Zick',
+    images: [
+      {
+        url: 'https://michaelzick.com/img/waterfall_2500.webp',
+        alt: 'Waterfall cascading over rocks',
+      },
+    ],
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Michael Zick | Work With Me',
+    description:
+      'Explore coaching programs with Michael Zick to achieve peak performance and lasting change.',
+    images: ['https://michaelzick.com/img/waterfall_2500.webp'],
+  },
+}
+
 export default function WorkWithMe() {
   return (
     <div className="flex flex-col">


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter metadata across site
- create page-specific titles, descriptions, and hero images for each page
- refactor contact page to support metadata export

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a901bad688320ba69ee021aed6f45