### PR TITLE
feat: darken work-with-me hero

### DIFF
--- a/app/work-with-me/page.tsx
+++ b/app/work-with-me/page.tsx
@@ -37,7 +37,7 @@ export default function WorkWithMe() {
             "url('/img/ocean_2500.webp')",
         }}
       >
-        <div className="absolute inset-0 bg-black/40" />
+        <div className="absolute inset-0 bg-black/30" />
         <div className="relative max-w-[1400px] mx-auto">
           <h1 className="text-[64px] font-semibold mb-6">Work With Me</h1>
           <h3 className="text-[35px] font-light max-w-[900px]">

--- a/app/work-with-me/page.tsx
+++ b/app/work-with-me/page.tsx
@@ -37,7 +37,8 @@ export default function WorkWithMe() {
             "url('/img/ocean_2500.webp')",
         }}
       >
-        <div className="max-w-[1400px] mx-auto">
+        <div className="absolute inset-0 bg-black/40" />
+        <div className="relative max-w-[1400px] mx-auto">
           <h1 className="text-[64px] font-semibold mb-6">Work With Me</h1>
           <h3 className="text-[35px] font-light max-w-[900px]">
             “You can&apos;t go back and change the beginning, but you can start where you are and change the ending.”


### PR DESCRIPTION
## Summary
- add a semi-transparent dark overlay to the Work With Me hero so text remains bright

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bc379e1f48320aaa7f2a73de66ff0