### PR TITLE
feat: add booking button to navigation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -22,8 +22,7 @@ html {
 
 @media (max-width: 929px) {
 
-  .nav-links-container,
-  .nav-button {
+  .nav-links-container {
     display: none;
   }
 
@@ -100,5 +99,9 @@ html {
     padding: 30px 42px;
     font-size: 16px;
     line-height: 16px;
+  }
+  .nav-button {
+    @apply inline-flex items-center justify-center rounded bg-primary-blue text-white transition-colors duration-200 hover:opacity-90 text-base leading-4;
+    padding: 8px 16px;
   }
 }

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -47,7 +47,7 @@ export default function NavBar() {
             Michael Zick
           </h1>
         </Link>
-        <div className="nav-links-container flex space-x-6 max-[929px]:hidden">
+        <div className="nav-links-container flex items-center space-x-6 max-[929px]:hidden">
           <Link
             href="/work-with-me"
             className={`nav-link text-2xl ${
@@ -80,6 +80,14 @@ export default function NavBar() {
           >
             Contact
           </Link>
+          <a
+            href="https://calendly.com/michaelzick/45min"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="nav-button"
+          >
+            Book a Session
+          </a>
         </div>
         <div
           className="header-burger menu-overlay-has-visible-non-navigation-items"
@@ -147,6 +155,15 @@ export default function NavBar() {
           >
             Contact
           </Link>
+          <a
+            href="https://calendly.com/michaelzick/45min"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="nav-button"
+            onClick={() => setMenuOpen(false)}
+          >
+            Book a Session
+          </a>
         </div>
     </header>
   )


### PR DESCRIPTION
## Summary
- add small "Book a Session" button to top nav linking to Calendly
- show booking button in mobile nav after "Contact"
- adjust responsive styles so the new button displays on mobile

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bedbf4a60083208684d072085a76c4