### PR TITLE
Add contact form and API endpoint

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -19,7 +19,9 @@ export async function POST(req: NextRequest) {
 
     // Lookup the SMTP password at runtime so builds without the
     // environment variable don't bake in an empty value.
-    const password = process.env['BREVO_SMTP_PASSWORD'];
+    const password =
+      process.env['VITE_BREVO_SMTP_PASSWORD'] ||
+      process.env['BREVO_SMTP_PASSWORD'];
     if (!password) {
       console.error('BREVO_SMTP_PASSWORD is not configured');
       return NextResponse.json(

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  const { firstName, lastName, email, subject, message } = await req.json();
+  console.log('Contact form submission', { firstName, lastName, email, subject, messageLength: message?.length });
+  return NextResponse.json({ success: true });
+}

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -4,6 +4,7 @@ import nodemailer from 'nodemailer';
 // Ensure the route runs in a Node.js environment so Node APIs like
 // nodemailer are available.
 export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
 
 export async function POST(req: NextRequest) {
   try {
@@ -16,7 +17,9 @@ export async function POST(req: NextRequest) {
       messageLength: message?.length,
     });
 
-    const password = process.env.BREVO_SMTP_PASSWORD;
+    // Lookup the SMTP password at runtime so builds without the
+    // environment variable don't bake in an empty value.
+    const password = process.env['BREVO_SMTP_PASSWORD'];
     if (!password) {
       console.error('BREVO_SMTP_PASSWORD is not configured');
       return NextResponse.json(

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -37,11 +37,13 @@ export async function POST(req: NextRequest) {
       },
     });
 
+    const prefixedSubject = `[michaelzick.com] ${subject}`;
+
     await transporter.sendMail({
-      from: '96ae20001@smtp-brevo.com',
+      from: 'michael@michaelzick.com',
       to: 'michael@michaelzick.com',
       replyTo: email,
-      subject,
+      subject: prefixedSubject,
       text: `Name: ${firstName} ${lastName}\nEmail: ${email}\n\n${message}`,
     });
 

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,7 +1,39 @@
 import { NextResponse } from 'next/server';
+import nodemailer from 'nodemailer';
 
 export async function POST(req: Request) {
   const { firstName, lastName, email, subject, message } = await req.json();
-  console.log('Contact form submission', { firstName, lastName, email, subject, messageLength: message?.length });
-  return NextResponse.json({ success: true });
+  console.log('Contact form submission', {
+    firstName,
+    lastName,
+    email,
+    subject,
+    messageLength: message?.length,
+  });
+
+  const transporter = nodemailer.createTransport({
+    host: 'smtp-relay.brevo.com',
+    port: 587,
+    auth: {
+      user: '96ae20001@smtp-brevo.com',
+      pass: process.env.BREVO_SMTP_PASSWORD,
+    },
+  });
+
+  try {
+    await transporter.sendMail({
+      from: '96ae20001@smtp-brevo.com',
+      to: '96ae20001@smtp-brevo.com',
+      replyTo: email,
+      subject,
+      text: `Name: ${firstName} ${lastName}\nEmail: ${email}\n\n${message}`,
+    });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error('Failed to send contact email', err);
+    return NextResponse.json(
+      { success: false, error: 'Failed to send email' },
+      { status: 500 },
+    );
+  }
 }

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -19,9 +19,7 @@ export async function POST(req: NextRequest) {
 
     // Lookup the SMTP password at runtime so builds without the
     // environment variable don't bake in an empty value.
-    const password =
-      process.env['VITE_BREVO_SMTP_PASSWORD'] ||
-      process.env['BREVO_SMTP_PASSWORD'];
+    const password = process.env['BREVO_SMTP_PASSWORD'];
     if (!password) {
       console.error('BREVO_SMTP_PASSWORD is not configured');
       return NextResponse.json(

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -39,7 +39,7 @@ export async function POST(req: NextRequest) {
 
     await transporter.sendMail({
       from: '96ae20001@smtp-brevo.com',
-      to: '96ae20001@smtp-brevo.com',
+      to: 'michael@michaelzick.com',
       replyTo: email,
       subject,
       text: `Name: ${firstName} ${lastName}\nEmail: ${email}\n\n${message}`,

--- a/app/contact/ContactContent.tsx
+++ b/app/contact/ContactContent.tsx
@@ -5,7 +5,7 @@ export default function ContactContent() {
   return (
     <div className="flex flex-col">
       <section
-        className="bg-default-grey h-screen text-white px-6 md:px-8 pt-40 md:pt-56 pb-24 md:pb-32"
+        className="bg-default-grey min-h-screen text-white px-6 md:px-8 pt-40 md:pt-56 pb-24 md:pb-32"
         style={{
           backgroundImage: "url('/img/lake_reflection_2500.webp')",
         }}
@@ -31,12 +31,10 @@ export default function ContactContent() {
               </a>
             </div>
           </div>
-        </div>
-      </section>
-      <section className="px-6 md:px-8 py-12">
-        <div className="max-w-[800px] mx-auto">
-          <h2 className="text-3xl font-semibold mb-6">Send a Message</h2>
-          <ContactForm />
+          <div className="md:col-span-7 bg-white text-black rounded p-6">
+            <h2 className="text-3xl font-semibold mb-6">Send a Message</h2>
+            <ContactForm />
+          </div>
         </div>
       </section>
     </div>

--- a/app/contact/ContactContent.tsx
+++ b/app/contact/ContactContent.tsx
@@ -1,12 +1,6 @@
-'use client';
-
-import { useEffect } from 'react';
-import { initMail64 } from '../../lib/mail64';
+import ContactForm from './ContactForm';
 
 export default function ContactContent() {
-  useEffect(() => {
-    initMail64();
-  }, []);
 
   return (
     <div className="flex flex-col">
@@ -19,9 +13,6 @@ export default function ContactContent() {
         <div className="max-w-[1400px] mx-auto grid md:grid-cols-12 gap-8">
           <div className="md:col-span-5 space-y-6">
             <h1 className="text-[64px] font-semibold">Contact</h1>
-            <a className="btn js-mail64" data-addr="Znc5bzVnNzJAYW5vbmFkZHkuY29t">
-              Email Me
-            </a>
             <h2 className="text-2xl font-semibold">Socials</h2>
             <div className="flex space-x-4">
               <a
@@ -40,6 +31,12 @@ export default function ContactContent() {
               </a>
             </div>
           </div>
+        </div>
+      </section>
+      <section className="px-6 md:px-8 py-12">
+        <div className="max-w-[800px] mx-auto">
+          <h2 className="text-3xl font-semibold mb-6">Send a Message</h2>
+          <ContactForm />
         </div>
       </section>
     </div>

--- a/app/contact/ContactContent.tsx
+++ b/app/contact/ContactContent.tsx
@@ -32,7 +32,7 @@ export default function ContactContent() {
             </div>
           </div>
           <div className="md:col-span-7 bg-white text-black rounded p-6">
-            <h2 className="text-3xl font-semibold mb-6">Send a Message</h2>
+            <h2 className="text-3xl font-semibold mb-6 text-default-grey">Send a Message</h2>
             <ContactForm />
           </div>
         </div>

--- a/app/contact/ContactForm.tsx
+++ b/app/contact/ContactForm.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useState } from 'react';
+
+interface FormData {
+  firstName: string;
+  lastName: string;
+  email: string;
+  subject: string;
+  message: string;
+}
+
+export default function ContactForm() {
+  const [formData, setFormData] = useState<FormData>({
+    firstName: '',
+    lastName: '',
+    email: '',
+    subject: '',
+    message: '',
+  });
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus('submitting');
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      setStatus('success');
+      setFormData({ firstName: '', lastName: '', email: '', subject: '', message: '' });
+    } catch (err) {
+      console.error(err);
+      setStatus('error');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <input
+          className="border border-gray-300 rounded p-2"
+          name="firstName"
+          placeholder="First Name"
+          value={formData.firstName}
+          onChange={handleChange}
+          required
+        />
+        <input
+          className="border border-gray-300 rounded p-2"
+          name="lastName"
+          placeholder="Last Name"
+          value={formData.lastName}
+          onChange={handleChange}
+          required
+        />
+      </div>
+      <input
+        className="border border-gray-300 rounded p-2 w-full"
+        type="email"
+        name="email"
+        placeholder="Email"
+        value={formData.email}
+        onChange={handleChange}
+        required
+      />
+      <input
+        className="border border-gray-300 rounded p-2 w-full"
+        name="subject"
+        placeholder="Subject"
+        value={formData.subject}
+        onChange={handleChange}
+        required
+      />
+      <textarea
+        className="border border-gray-300 rounded p-2 w-full min-h-[120px]"
+        name="message"
+        placeholder="Message"
+        value={formData.message}
+        onChange={handleChange}
+        required
+      />
+      {status === 'success' && (
+        <p className="text-green-600">Your message has been sent.</p>
+      )}
+      {status === 'error' && (
+        <p className="text-red-600">There was an error sending your message.</p>
+      )}
+      <button
+        type="submit"
+        className="bg-blue-600 text-white px-4 py-2 rounded"
+        disabled={status === 'submitting'}
+      >
+        {status === 'submitting' ? 'Sending...' : 'Send'}
+      </button>
+    </form>
+  );
+}
+

--- a/app/contact/ContactForm.tsx
+++ b/app/contact/ContactForm.tsx
@@ -49,7 +49,7 @@ export default function ContactForm() {
     <form onSubmit={handleSubmit} className="space-y-4">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <input
-          className="border border-gray-300 rounded p-2"
+          className="border border-gray-300 rounded p-2 text-black"
           name="firstName"
           placeholder="First Name"
           value={formData.firstName}
@@ -57,7 +57,7 @@ export default function ContactForm() {
           required
         />
         <input
-          className="border border-gray-300 rounded p-2"
+          className="border border-gray-300 rounded p-2 text-black"
           name="lastName"
           placeholder="Last Name"
           value={formData.lastName}
@@ -66,7 +66,7 @@ export default function ContactForm() {
         />
       </div>
       <input
-        className="border border-gray-300 rounded p-2 w-full"
+        className="border border-gray-300 rounded p-2 w-full text-black"
         type="email"
         name="email"
         placeholder="Email"
@@ -75,7 +75,7 @@ export default function ContactForm() {
         required
       />
       <input
-        className="border border-gray-300 rounded p-2 w-full"
+        className="border border-gray-300 rounded p-2 w-full text-black"
         name="subject"
         placeholder="Subject"
         value={formData.subject}
@@ -83,7 +83,7 @@ export default function ContactForm() {
         required
       />
       <textarea
-        className="border border-gray-300 rounded p-2 w-full min-h-[120px]"
+        className="border border-gray-300 rounded p-2 w-full min-h-[120px] text-black"
         name="message"
         placeholder="Message"
         value={formData.message}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
-  output: 'export',
   images: {
     domains: ['www.michaelzick.com', 'michaelzick.com'],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "latest",
         "react": "latest",
-        "react-dom": "latest"
+        "react-dom": "latest",
+        "nodemailer": "^7.0.6"
       },
       "devDependencies": {
         "@types/node": "latest",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "next": "latest",
     "react": "latest",
-    "react-dom": "latest"
+    "react-dom": "latest",
+    "nodemailer": "latest"
   },
   "devDependencies": {
     "@types/node": "latest",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "next": "latest",
     "react": "latest",
     "react-dom": "latest",
-    "nodemailer": "latest"
+    "nodemailer": "^7.0.6"
   },
   "devDependencies": {
     "@types/node": "latest",


### PR DESCRIPTION
## Summary
- Replace contact button with full-featured form on contact page
- Add API route to receive contact submissions
- Preserve Socials section while integrating new ContactForm component

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c09273222c83209ff8d9acd4f6d150