### PR TITLE
Add HubSpot sync for coupon and newsletter opt-ins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Sibling files [CLAUDE.md](CLAUDE.md) (Claude Code) and [GEMINI.md](GEMINI.md) (G
 Primary flows:
 - Visitors learn about Michael's coaching model through the home, about, testimonials, contact, and Nice Guy University pages.
 - Visitors submit a multi-step questionnaire and receive an OpenAI-generated coaching analysis.
-- Contact and NGU coupon forms validate Invisible reCAPTCHA v2, rate-limit submissions, and send Brevo SMTP email notifications.
+- Contact and NGU coupon forms validate Invisible reCAPTCHA v2, rate-limit submissions, send Brevo SMTP email notifications, and sync newsletter opt-ins to HubSpot as male subscribers.
 - Blog readers browse JSON-backed posts with category/tag filters and structured data for SEO.
 - CTA and navigation interactions are tracked through a shared analytics wrapper for GA4 and Amplitude.
 
@@ -22,7 +22,7 @@ Primary flows:
 - **Framework:** Next.js 16 App Router with React 19 and TypeScript; the package is currently pinned to the patched 16.3 canary line until the same security fixes land in a stable release.
 - **Styling:** Tailwind CSS 3, global styles in `app/globals.css`, image assets in `public/img/`.
 - **Server routes:** Next route handlers under `app/api/*`, using Node runtime where email/OpenAI APIs are needed.
-- **AI and email:** OpenAI Node SDK for questionnaire analysis; Nodemailer with Brevo SMTP for notifications.
+- **AI, email, and CRM:** OpenAI Node SDK for questionnaire analysis; Nodemailer with Brevo SMTP for notifications; HubSpot CRM API for newsletter subscriber sync.
 - **Bot protection:** Classic Invisible reCAPTCHA v2 via `NEXT_PUBLIC_RECAPTCHA_SITE_KEY_V2` and `RECAPTCHA_SECRET_KEY_V2`.
 - **Analytics:** GA4 and Amplitude scripts in `components/SiteAnalyticsScripts.tsx`; tracked events in `lib/analytics.ts`.
 - **Testing:** Node's built-in test runner for compiled unit tests, TypeScript test build via `tsconfig.test.json`, and Playwright for E2E/mobile UI checks.
@@ -62,9 +62,9 @@ michaelzick.com/
 ### 4.2 API routes
 
 - `app/api/analyze/route.ts` accepts questionnaire submissions, applies honeypot/rate limiting/length checks, calls OpenAI (`gpt-5-mini` with fallback to `gpt-4o-mini`), and optionally emails the result via Brevo SMTP.
-- `app/api/contact/route.ts` validates contact submissions, enforces per-IP rate limits, verifies Invisible reCAPTCHA v2, and sends contact email via Brevo.
-- `app/api/ngu-coupon/route.ts` validates NGU coupon signups, verifies reCAPTCHA, sends the visitor coupon email, and sends the internal notification email.
-- Shared server helpers live in `lib/server/`: contact and NGU normalization/validation/email builders, OpenAI client construction, and in-memory rate limiting.
+- `app/api/contact/route.ts` validates contact submissions, enforces per-IP rate limits, verifies Invisible reCAPTCHA v2, sends contact email via Brevo, and best-effort syncs HubSpot when the workbook/newsletter opt-in is selected.
+- `app/api/ngu-coupon/route.ts` validates NGU coupon signups, verifies reCAPTCHA, sends the visitor coupon email, sends the internal notification email, and best-effort syncs the email to HubSpot.
+- Shared server helpers live in `lib/server/`: contact and NGU normalization/validation/email builders, HubSpot subscriber sync, OpenAI client construction, and in-memory rate limiting.
 
 ### 4.3 Components and client behavior
 
@@ -90,6 +90,9 @@ No committed `.env.example` currently exists. Environment variables used by the 
 
 - `OPENAI_API_KEY` — required for questionnaire analysis.
 - `BREVO_SMTP_PASSWORD`, `BREVO_USER`, `BREVO_TO`, `BREVO_FROM` — required for contact and NGU email routes; optional for questionnaire result notification.
+- `HUBSPOT_SERVICE_KEY` — preferred HubSpot Private App bearer token for newsletter subscriber sync.
+- `HUBSPOT_ACCESS_TOKEN`, `HUBSPOT_PRIVATE_APP_TOKEN` — legacy HubSpot token fallbacks when `HUBSPOT_SERVICE_KEY` is not set.
+- `HUBSPOT_CONTACT_OWNER_ID` — required HubSpot owner ID for newsletter subscriber contacts and notes.
 - `NEXT_PUBLIC_RECAPTCHA_SITE_KEY_V2` — public Invisible reCAPTCHA v2 site key used by browser forms.
 - `RECAPTCHA_SECRET_KEY_V2` — server-side Invisible reCAPTCHA v2 secret used with Google `siteverify`.
 - `SITE_URL` — optional sitemap generation override; defaults to `https://www.michaelzick.com`.
@@ -148,6 +151,7 @@ CI runs the brief sync check, lint, typecheck, unit tests, production build, and
 | [app/api/contact/route.ts](app/api/contact/route.ts) | Contact email + reCAPTCHA route |
 | [app/api/ngu-coupon/route.ts](app/api/ngu-coupon/route.ts) | NGU coupon email + reCAPTCHA route |
 | [lib/server/contact.ts](lib/server/contact.ts) | Contact normalization, validation, config, email text |
+| [lib/server/hubspot-subscriber.ts](lib/server/hubspot-subscriber.ts) | HubSpot CRM contact upsert and subscriber note sync |
 | [lib/server/ngu-coupon.ts](lib/server/ngu-coupon.ts) | NGU coupon normalization, validation, config, email text |
 | [lib/server/rate-limit.ts](lib/server/rate-limit.ts) | In-memory rate limiting helpers |
 | [lib/blog.ts](lib/blog.ts) | Blog post normalization and filters |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Sibling files [AGENTS.md](AGENTS.md) (Codex) and [GEMINI.md](GEMINI.md) (Gemini 
 Primary flows:
 - Visitors learn about Michael's coaching model through the home, about, testimonials, contact, and Nice Guy University pages.
 - Visitors submit a multi-step questionnaire and receive an OpenAI-generated coaching analysis.
-- Contact and NGU coupon forms validate Invisible reCAPTCHA v2, rate-limit submissions, and send Brevo SMTP email notifications.
+- Contact and NGU coupon forms validate Invisible reCAPTCHA v2, rate-limit submissions, send Brevo SMTP email notifications, and sync newsletter opt-ins to HubSpot as male subscribers.
 - Blog readers browse JSON-backed posts with category/tag filters and structured data for SEO.
 - CTA and navigation interactions are tracked through a shared analytics wrapper for GA4 and Amplitude.
 
@@ -22,7 +22,7 @@ Primary flows:
 - **Framework:** Next.js 16 App Router with React 19 and TypeScript; the package is currently pinned to the patched 16.3 canary line until the same security fixes land in a stable release.
 - **Styling:** Tailwind CSS 3, global styles in `app/globals.css`, image assets in `public/img/`.
 - **Server routes:** Next route handlers under `app/api/*`, using Node runtime where email/OpenAI APIs are needed.
-- **AI and email:** OpenAI Node SDK for questionnaire analysis; Nodemailer with Brevo SMTP for notifications.
+- **AI, email, and CRM:** OpenAI Node SDK for questionnaire analysis; Nodemailer with Brevo SMTP for notifications; HubSpot CRM API for newsletter subscriber sync.
 - **Bot protection:** Classic Invisible reCAPTCHA v2 via `NEXT_PUBLIC_RECAPTCHA_SITE_KEY_V2` and `RECAPTCHA_SECRET_KEY_V2`.
 - **Analytics:** GA4 and Amplitude scripts in `components/SiteAnalyticsScripts.tsx`; tracked events in `lib/analytics.ts`.
 - **Testing:** Node's built-in test runner for compiled unit tests, TypeScript test build via `tsconfig.test.json`, and Playwright for E2E/mobile UI checks.
@@ -62,9 +62,9 @@ michaelzick.com/
 ### 4.2 API routes
 
 - `app/api/analyze/route.ts` accepts questionnaire submissions, applies honeypot/rate limiting/length checks, calls OpenAI (`gpt-5-mini` with fallback to `gpt-4o-mini`), and optionally emails the result via Brevo SMTP.
-- `app/api/contact/route.ts` validates contact submissions, enforces per-IP rate limits, verifies Invisible reCAPTCHA v2, and sends contact email via Brevo.
-- `app/api/ngu-coupon/route.ts` validates NGU coupon signups, verifies reCAPTCHA, sends the visitor coupon email, and sends the internal notification email.
-- Shared server helpers live in `lib/server/`: contact and NGU normalization/validation/email builders, OpenAI client construction, and in-memory rate limiting.
+- `app/api/contact/route.ts` validates contact submissions, enforces per-IP rate limits, verifies Invisible reCAPTCHA v2, sends contact email via Brevo, and best-effort syncs HubSpot when the workbook/newsletter opt-in is selected.
+- `app/api/ngu-coupon/route.ts` validates NGU coupon signups, verifies reCAPTCHA, sends the visitor coupon email, sends the internal notification email, and best-effort syncs the email to HubSpot.
+- Shared server helpers live in `lib/server/`: contact and NGU normalization/validation/email builders, HubSpot subscriber sync, OpenAI client construction, and in-memory rate limiting.
 
 ### 4.3 Components and client behavior
 
@@ -90,6 +90,9 @@ No committed `.env.example` currently exists. Environment variables used by the 
 
 - `OPENAI_API_KEY` — required for questionnaire analysis.
 - `BREVO_SMTP_PASSWORD`, `BREVO_USER`, `BREVO_TO`, `BREVO_FROM` — required for contact and NGU email routes; optional for questionnaire result notification.
+- `HUBSPOT_SERVICE_KEY` — preferred HubSpot Private App bearer token for newsletter subscriber sync.
+- `HUBSPOT_ACCESS_TOKEN`, `HUBSPOT_PRIVATE_APP_TOKEN` — legacy HubSpot token fallbacks when `HUBSPOT_SERVICE_KEY` is not set.
+- `HUBSPOT_CONTACT_OWNER_ID` — required HubSpot owner ID for newsletter subscriber contacts and notes.
 - `NEXT_PUBLIC_RECAPTCHA_SITE_KEY_V2` — public Invisible reCAPTCHA v2 site key used by browser forms.
 - `RECAPTCHA_SECRET_KEY_V2` — server-side Invisible reCAPTCHA v2 secret used with Google `siteverify`.
 - `SITE_URL` — optional sitemap generation override; defaults to `https://www.michaelzick.com`.
@@ -148,6 +151,7 @@ CI runs the brief sync check, lint, typecheck, unit tests, production build, and
 | [app/api/contact/route.ts](app/api/contact/route.ts) | Contact email + reCAPTCHA route |
 | [app/api/ngu-coupon/route.ts](app/api/ngu-coupon/route.ts) | NGU coupon email + reCAPTCHA route |
 | [lib/server/contact.ts](lib/server/contact.ts) | Contact normalization, validation, config, email text |
+| [lib/server/hubspot-subscriber.ts](lib/server/hubspot-subscriber.ts) | HubSpot CRM contact upsert and subscriber note sync |
 | [lib/server/ngu-coupon.ts](lib/server/ngu-coupon.ts) | NGU coupon normalization, validation, config, email text |
 | [lib/server/rate-limit.ts](lib/server/rate-limit.ts) | In-memory rate limiting helpers |
 | [lib/blog.ts](lib/blog.ts) | Blog post normalization and filters |

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -13,7 +13,7 @@ Sibling files [CLAUDE.md](CLAUDE.md) (Claude Code) and [AGENTS.md](AGENTS.md) (C
 Primary flows:
 - Visitors learn about Michael's coaching model through the home, about, testimonials, contact, and Nice Guy University pages.
 - Visitors submit a multi-step questionnaire and receive an OpenAI-generated coaching analysis.
-- Contact and NGU coupon forms validate Invisible reCAPTCHA v2, rate-limit submissions, and send Brevo SMTP email notifications.
+- Contact and NGU coupon forms validate Invisible reCAPTCHA v2, rate-limit submissions, send Brevo SMTP email notifications, and sync newsletter opt-ins to HubSpot as male subscribers.
 - Blog readers browse JSON-backed posts with category/tag filters and structured data for SEO.
 - CTA and navigation interactions are tracked through a shared analytics wrapper for GA4 and Amplitude.
 
@@ -22,7 +22,7 @@ Primary flows:
 - **Framework:** Next.js 16 App Router with React 19 and TypeScript; the package is currently pinned to the patched 16.3 canary line until the same security fixes land in a stable release.
 - **Styling:** Tailwind CSS 3, global styles in `app/globals.css`, image assets in `public/img/`.
 - **Server routes:** Next route handlers under `app/api/*`, using Node runtime where email/OpenAI APIs are needed.
-- **AI and email:** OpenAI Node SDK for questionnaire analysis; Nodemailer with Brevo SMTP for notifications.
+- **AI, email, and CRM:** OpenAI Node SDK for questionnaire analysis; Nodemailer with Brevo SMTP for notifications; HubSpot CRM API for newsletter subscriber sync.
 - **Bot protection:** Classic Invisible reCAPTCHA v2 via `NEXT_PUBLIC_RECAPTCHA_SITE_KEY_V2` and `RECAPTCHA_SECRET_KEY_V2`.
 - **Analytics:** GA4 and Amplitude scripts in `components/SiteAnalyticsScripts.tsx`; tracked events in `lib/analytics.ts`.
 - **Testing:** Node's built-in test runner for compiled unit tests, TypeScript test build via `tsconfig.test.json`, and Playwright for E2E/mobile UI checks.
@@ -62,9 +62,9 @@ michaelzick.com/
 ### 4.2 API routes
 
 - `app/api/analyze/route.ts` accepts questionnaire submissions, applies honeypot/rate limiting/length checks, calls OpenAI (`gpt-5-mini` with fallback to `gpt-4o-mini`), and optionally emails the result via Brevo SMTP.
-- `app/api/contact/route.ts` validates contact submissions, enforces per-IP rate limits, verifies Invisible reCAPTCHA v2, and sends contact email via Brevo.
-- `app/api/ngu-coupon/route.ts` validates NGU coupon signups, verifies reCAPTCHA, sends the visitor coupon email, and sends the internal notification email.
-- Shared server helpers live in `lib/server/`: contact and NGU normalization/validation/email builders, OpenAI client construction, and in-memory rate limiting.
+- `app/api/contact/route.ts` validates contact submissions, enforces per-IP rate limits, verifies Invisible reCAPTCHA v2, sends contact email via Brevo, and best-effort syncs HubSpot when the workbook/newsletter opt-in is selected.
+- `app/api/ngu-coupon/route.ts` validates NGU coupon signups, verifies reCAPTCHA, sends the visitor coupon email, sends the internal notification email, and best-effort syncs the email to HubSpot.
+- Shared server helpers live in `lib/server/`: contact and NGU normalization/validation/email builders, HubSpot subscriber sync, OpenAI client construction, and in-memory rate limiting.
 
 ### 4.3 Components and client behavior
 
@@ -90,6 +90,9 @@ No committed `.env.example` currently exists. Environment variables used by the 
 
 - `OPENAI_API_KEY` — required for questionnaire analysis.
 - `BREVO_SMTP_PASSWORD`, `BREVO_USER`, `BREVO_TO`, `BREVO_FROM` — required for contact and NGU email routes; optional for questionnaire result notification.
+- `HUBSPOT_SERVICE_KEY` — preferred HubSpot Private App bearer token for newsletter subscriber sync.
+- `HUBSPOT_ACCESS_TOKEN`, `HUBSPOT_PRIVATE_APP_TOKEN` — legacy HubSpot token fallbacks when `HUBSPOT_SERVICE_KEY` is not set.
+- `HUBSPOT_CONTACT_OWNER_ID` — required HubSpot owner ID for newsletter subscriber contacts and notes.
 - `NEXT_PUBLIC_RECAPTCHA_SITE_KEY_V2` — public Invisible reCAPTCHA v2 site key used by browser forms.
 - `RECAPTCHA_SECRET_KEY_V2` — server-side Invisible reCAPTCHA v2 secret used with Google `siteverify`.
 - `SITE_URL` — optional sitemap generation override; defaults to `https://www.michaelzick.com`.
@@ -148,6 +151,7 @@ CI runs the brief sync check, lint, typecheck, unit tests, production build, and
 | [app/api/contact/route.ts](app/api/contact/route.ts) | Contact email + reCAPTCHA route |
 | [app/api/ngu-coupon/route.ts](app/api/ngu-coupon/route.ts) | NGU coupon email + reCAPTCHA route |
 | [lib/server/contact.ts](lib/server/contact.ts) | Contact normalization, validation, config, email text |
+| [lib/server/hubspot-subscriber.ts](lib/server/hubspot-subscriber.ts) | HubSpot CRM contact upsert and subscriber note sync |
 | [lib/server/ngu-coupon.ts](lib/server/ngu-coupon.ts) | NGU coupon normalization, validation, config, email text |
 | [lib/server/rate-limit.ts](lib/server/rate-limit.ts) | In-memory rate limiting helpers |
 | [lib/blog.ts](lib/blog.ts) | Blog post normalization and filters |

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -10,6 +10,7 @@ import {
   normalizeContactSubmission,
   validateContactSubmission,
 } from '../../../lib/server/contact';
+import { syncHubSpotSubscriberSafely } from '../../../lib/server/hubspot-subscriber';
 import { consumeRateLimit, getClientIp } from '../../../lib/server/rate-limit';
 
 // Ensure the route runs in a Node.js environment so Node APIs like
@@ -110,6 +111,14 @@ export async function POST(req: NextRequest) {
       subject: email.subject,
       text: email.text,
     });
+
+    if (submission.workbookOptIn) {
+      await syncHubSpotSubscriberSafely({
+        email: submission.email,
+        firstName: submission.firstName,
+        lastName: submission.lastName,
+      });
+    }
 
     return NextResponse.json({ success: true });
   } catch (err) {

--- a/app/api/ngu-coupon/route.ts
+++ b/app/api/ngu-coupon/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import nodemailer from 'nodemailer';
 import { RECAPTCHA_SITE_VERIFY_URL } from '../../../lib/recaptcha';
+import { syncHubSpotSubscriberSafely } from '../../../lib/server/hubspot-subscriber';
 import { consumeRateLimit, getClientIp } from '../../../lib/server/rate-limit';
 import {
   buildNguCouponNotificationEmail,
@@ -107,6 +108,8 @@ export async function POST(req: NextRequest) {
       subject: notificationEmail.subject,
       text: notificationEmail.text,
     });
+
+    await syncHubSpotSubscriberSafely({ email: submission.email });
 
     return NextResponse.json({ success: true });
   } catch (err) {

--- a/lib/server/hubspot-subscriber.ts
+++ b/lib/server/hubspot-subscriber.ts
@@ -1,0 +1,516 @@
+export const HUBSPOT_FIRST_ENTRY_NOTE = 'First entry: michaelzick.com';
+export const HUBSPOT_EXISTING_ENTRY_NOTE = 'Existing entry: michaelzick.com';
+
+export type HubSpotSubscriberInput = {
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+};
+
+export type HubSpotSubscriberConfig = {
+  accessToken: string;
+  ownerId: string;
+};
+
+export type HubSpotSubscriberNoteBody =
+  | typeof HUBSPOT_FIRST_ENTRY_NOTE
+  | typeof HUBSPOT_EXISTING_ENTRY_NOTE;
+
+export type HubSpotSubscriberSyncResult = {
+  contactId: string;
+  wasExistingContact: boolean;
+  noteBody: HubSpotSubscriberNoteBody;
+  noteCreated: boolean;
+};
+
+export type HubSpotSubscriberSyncStatus =
+  | ({ status: 'synced' } & HubSpotSubscriberSyncResult)
+  | { status: 'error'; error: string };
+
+type ValidatedHubSpotSubscriberInput = {
+  email: string;
+  firstName?: string;
+  lastName?: string;
+};
+
+type HubSpotSubscriberSyncOptions = {
+  env?: NodeJS.ProcessEnv;
+  fetch?: typeof fetch;
+  now?: () => Date;
+};
+
+type SafeHubSpotSubscriberSyncOptions = HubSpotSubscriberSyncOptions & {
+  logError?: (message: string, error: unknown) => void;
+};
+
+type HubSpotSearchResponse = {
+  results?: Array<{ id?: string | number }>;
+};
+
+type HubSpotObjectResponse = {
+  id?: string | number;
+};
+
+type HubSpotAssociationsResponse = {
+  results?: Array<{ toObjectId?: string | number }>;
+  paging?: {
+    next?: {
+      after?: string | number;
+    };
+  };
+};
+
+type HubSpotNotesBatchReadResponse = {
+  results?: Array<{
+    id?: string | number;
+    properties?: {
+      hs_note_body?: string | null;
+    } | null;
+  }>;
+};
+
+type HubSpotContactProperties = {
+  email: string;
+  firstname?: string;
+  lastname?: string;
+  gender: 'Male';
+  lifecyclestage: 'subscriber';
+  hubspot_owner_id: string;
+};
+
+const HUBSPOT_API_BASE_URL = 'https://api.hubapi.com';
+const HUBSPOT_SYNC_ERROR_MESSAGE = 'Unable to sync HubSpot subscriber.';
+const HUBSPOT_ASSOCIATIONS_PAGE_LIMIT = 100;
+const HUBSPOT_BATCH_READ_LIMIT = 100;
+const NOTE_TO_CONTACT_ASSOCIATION_TYPE_ID = 202;
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MICHAELZICK_ENTRY_NOTE_BODIES = new Set<HubSpotSubscriberNoteBody>([
+  HUBSPOT_FIRST_ENTRY_NOTE,
+  HUBSPOT_EXISTING_ENTRY_NOTE,
+]);
+
+export class HubSpotSubscriberSyncError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'HubSpotSubscriberSyncError';
+    this.status = status;
+  }
+}
+
+class HubSpotApiError extends Error {
+  apiStatus: number;
+
+  constructor(apiStatus: number) {
+    super(HUBSPOT_SYNC_ERROR_MESSAGE);
+    this.name = 'HubSpotApiError';
+    this.apiStatus = apiStatus;
+  }
+}
+
+function normalizeEmail(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function normalizeOptionalName(value: string | undefined) {
+  const normalized = value?.trim();
+  return normalized || undefined;
+}
+
+function isMichaelZickEntryNoteBody(value: unknown): value is HubSpotSubscriberNoteBody {
+  return typeof value === 'string'
+    && MICHAELZICK_ENTRY_NOTE_BODIES.has(value as HubSpotSubscriberNoteBody);
+}
+
+function isValidEmail(value: string) {
+  return EMAIL_PATTERN.test(value);
+}
+
+function chunkValues<T>(values: T[], size: number) {
+  const chunks: T[][] = [];
+  for (let index = 0; index < values.length; index += size) {
+    chunks.push(values.slice(index, index + size));
+  }
+  return chunks;
+}
+
+function getHubSpotAccessToken(env: NodeJS.ProcessEnv) {
+  return env['HUBSPOT_SERVICE_KEY']?.trim()
+    || env['HUBSPOT_ACCESS_TOKEN']?.trim()
+    || env['HUBSPOT_PRIVATE_APP_TOKEN']?.trim();
+}
+
+function getHubSpotErrorMessage(error: unknown) {
+  if (error instanceof HubSpotSubscriberSyncError) return error.message;
+  return HUBSPOT_SYNC_ERROR_MESSAGE;
+}
+
+export function normalizeHubSpotSubscriberInput(
+  input: HubSpotSubscriberInput,
+): HubSpotSubscriberInput {
+  return {
+    email: typeof input.email === 'string' ? normalizeEmail(input.email) : undefined,
+    firstName: normalizeOptionalName(input.firstName),
+    lastName: normalizeOptionalName(input.lastName),
+  };
+}
+
+export function validateHubSpotSubscriberInput(input: HubSpotSubscriberInput) {
+  if (!input.email) {
+    return 'Subscriber email is required.';
+  }
+
+  if (input.email.length > 100 || !isValidEmail(input.email)) {
+    return 'Subscriber email must be valid.';
+  }
+
+  if (
+    (input.firstName && input.firstName.length > 50)
+    || (input.lastName && input.lastName.length > 50)
+  ) {
+    return 'Subscriber name fields exceed character limits.';
+  }
+
+  return null;
+}
+
+export function getHubSpotSubscriberConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): HubSpotSubscriberConfig | null {
+  const accessToken = getHubSpotAccessToken(env);
+  const ownerId = env['HUBSPOT_CONTACT_OWNER_ID']?.trim();
+
+  if (!accessToken || !ownerId) {
+    return null;
+  }
+
+  return { accessToken, ownerId };
+}
+
+async function parseHubSpotResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    throw new HubSpotApiError(response.status);
+  }
+
+  if (response.status === 204) {
+    return {} as T;
+  }
+
+  const text = await response.text();
+  return text ? JSON.parse(text) as T : {} as T;
+}
+
+async function hubSpotRequest<T>(
+  fetchFn: typeof fetch,
+  token: string,
+  path: string,
+  init: RequestInit,
+) {
+  const response = await fetchFn(`${HUBSPOT_API_BASE_URL}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  return await parseHubSpotResponse<T>(response);
+}
+
+async function findContactIdByEmail(
+  fetchFn: typeof fetch,
+  token: string,
+  email: string,
+) {
+  const response = await hubSpotRequest<HubSpotSearchResponse>(
+    fetchFn,
+    token,
+    '/crm/v3/objects/contacts/search',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        filterGroups: [
+          {
+            filters: [
+              {
+                propertyName: 'email',
+                operator: 'EQ',
+                value: email,
+              },
+            ],
+          },
+        ],
+        properties: ['email'],
+        limit: 1,
+      }),
+    },
+  );
+
+  const id = response.results?.[0]?.id;
+  return id === undefined ? null : String(id);
+}
+
+async function updateContact(
+  fetchFn: typeof fetch,
+  token: string,
+  contactId: string,
+  properties: HubSpotContactProperties,
+) {
+  await hubSpotRequest<HubSpotObjectResponse>(
+    fetchFn,
+    token,
+    `/crm/v3/objects/contacts/${encodeURIComponent(contactId)}`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify({ properties }),
+    },
+  );
+}
+
+async function createContact(
+  fetchFn: typeof fetch,
+  token: string,
+  properties: HubSpotContactProperties,
+) {
+  const response = await hubSpotRequest<HubSpotObjectResponse>(
+    fetchFn,
+    token,
+    '/crm/v3/objects/contacts',
+    {
+      method: 'POST',
+      body: JSON.stringify({ properties }),
+    },
+  );
+
+  if (response.id === undefined) {
+    throw new HubSpotApiError(502);
+  }
+
+  return String(response.id);
+}
+
+async function upsertContact(
+  fetchFn: typeof fetch,
+  token: string,
+  properties: HubSpotContactProperties,
+) {
+  const existingContactId = await findContactIdByEmail(fetchFn, token, properties.email);
+  if (existingContactId) {
+    await updateContact(fetchFn, token, existingContactId, properties);
+    return { contactId: existingContactId, wasExistingContact: true };
+  }
+
+  try {
+    const contactId = await createContact(fetchFn, token, properties);
+    return { contactId, wasExistingContact: false };
+  } catch (error) {
+    if (!(error instanceof HubSpotApiError) || error.apiStatus !== 409) {
+      throw error;
+    }
+
+    const retriedContactId = await findContactIdByEmail(fetchFn, token, properties.email);
+    if (!retriedContactId) {
+      throw error;
+    }
+
+    await updateContact(fetchFn, token, retriedContactId, properties);
+    return { contactId: retriedContactId, wasExistingContact: true };
+  }
+}
+
+async function getAssociatedNoteIds(
+  fetchFn: typeof fetch,
+  token: string,
+  contactId: string,
+) {
+  const noteIds: string[] = [];
+  let after: string | null = null;
+
+  do {
+    const searchParams = new URLSearchParams({
+      limit: String(HUBSPOT_ASSOCIATIONS_PAGE_LIMIT),
+    });
+    if (after) {
+      searchParams.set('after', after);
+    }
+
+    const response = await hubSpotRequest<HubSpotAssociationsResponse>(
+      fetchFn,
+      token,
+      `/crm/v4/objects/contact/${encodeURIComponent(contactId)}/associations/notes?${searchParams.toString()}`,
+      { method: 'GET' },
+    );
+
+    for (const result of response.results ?? []) {
+      if (result.toObjectId !== undefined) {
+        noteIds.push(String(result.toObjectId));
+      }
+    }
+
+    after = response.paging?.next?.after === undefined
+      ? null
+      : String(response.paging.next.after);
+  } while (after);
+
+  return noteIds;
+}
+
+async function readNotesById(
+  fetchFn: typeof fetch,
+  token: string,
+  noteIds: string[],
+) {
+  const response = await hubSpotRequest<HubSpotNotesBatchReadResponse>(
+    fetchFn,
+    token,
+    '/crm/v3/objects/notes/batch/read',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        inputs: noteIds.map((id) => ({ id })),
+        properties: ['hs_note_body'],
+      }),
+    },
+  );
+
+  return response.results ?? [];
+}
+
+async function hasMichaelZickEntryNote(
+  fetchFn: typeof fetch,
+  token: string,
+  contactId: string,
+) {
+  const noteIds = await getAssociatedNoteIds(fetchFn, token, contactId);
+  if (noteIds.length === 0) return false;
+
+  for (const noteIdChunk of chunkValues(noteIds, HUBSPOT_BATCH_READ_LIMIT)) {
+    const notes = await readNotesById(fetchFn, token, noteIdChunk);
+    const matchingNote = notes.find((note) => (
+      isMichaelZickEntryNoteBody(note.properties?.hs_note_body)
+    ));
+    if (matchingNote) return true;
+  }
+
+  return false;
+}
+
+async function createContactNote(
+  fetchFn: typeof fetch,
+  token: string,
+  ownerId: string,
+  contactId: string,
+  noteBody: HubSpotSubscriberNoteBody,
+  now: () => Date,
+) {
+  const note = await hubSpotRequest<HubSpotObjectResponse>(
+    fetchFn,
+    token,
+    '/crm/v3/objects/notes',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        properties: {
+          hs_note_body: noteBody,
+          hs_timestamp: now().toISOString(),
+          hubspot_owner_id: ownerId,
+        },
+      }),
+    },
+  );
+
+  if (note.id === undefined) {
+    throw new HubSpotApiError(502);
+  }
+
+  await hubSpotRequest<Record<string, unknown>>(
+    fetchFn,
+    token,
+    `/crm/v3/objects/notes/${encodeURIComponent(String(note.id))}/associations/contact/${encodeURIComponent(contactId)}/${NOTE_TO_CONTACT_ASSOCIATION_TYPE_ID}`,
+    { method: 'PUT' },
+  );
+}
+
+export async function syncHubSpotSubscriber(
+  input: HubSpotSubscriberInput,
+  options: HubSpotSubscriberSyncOptions = {},
+): Promise<HubSpotSubscriberSyncResult> {
+  const normalized = normalizeHubSpotSubscriberInput(input);
+  const validationError = validateHubSpotSubscriberInput(normalized);
+  if (validationError) {
+    throw new HubSpotSubscriberSyncError(400, validationError);
+  }
+
+  const env = options.env ?? process.env;
+  const config = getHubSpotSubscriberConfig(env);
+  if (!config) {
+    throw new HubSpotSubscriberSyncError(500, 'HubSpot subscriber sync is not configured.');
+  }
+
+  const validatedInput = normalized as ValidatedHubSpotSubscriberInput;
+  const fetchFn = options.fetch ?? fetch;
+  const now = options.now ?? (() => new Date());
+  const properties: HubSpotContactProperties = {
+    email: validatedInput.email,
+    gender: 'Male',
+    lifecyclestage: 'subscriber',
+    hubspot_owner_id: config.ownerId,
+  };
+
+  if (validatedInput.firstName) {
+    properties.firstname = validatedInput.firstName;
+  }
+  if (validatedInput.lastName) {
+    properties.lastname = validatedInput.lastName;
+  }
+
+  try {
+    const { contactId, wasExistingContact } = await upsertContact(
+      fetchFn,
+      config.accessToken,
+      properties,
+    );
+    const noteBody = wasExistingContact
+      ? HUBSPOT_EXISTING_ENTRY_NOTE
+      : HUBSPOT_FIRST_ENTRY_NOTE;
+    const alreadyHasEntryNote = await hasMichaelZickEntryNote(
+      fetchFn,
+      config.accessToken,
+      contactId,
+    );
+    let noteCreated = false;
+
+    if (!alreadyHasEntryNote) {
+      await createContactNote(fetchFn, config.accessToken, config.ownerId, contactId, noteBody, now);
+      noteCreated = true;
+    }
+
+    return {
+      contactId,
+      wasExistingContact,
+      noteBody,
+      noteCreated,
+    };
+  } catch (error) {
+    if (error instanceof HubSpotSubscriberSyncError) {
+      throw error;
+    }
+
+    throw new HubSpotSubscriberSyncError(502, HUBSPOT_SYNC_ERROR_MESSAGE);
+  }
+}
+
+export async function syncHubSpotSubscriberSafely(
+  input: HubSpotSubscriberInput,
+  options: SafeHubSpotSubscriberSyncOptions = {},
+): Promise<HubSpotSubscriberSyncStatus> {
+  try {
+    const result = await syncHubSpotSubscriber(input, options);
+    return { status: 'synced', ...result };
+  } catch (error) {
+    const logError = options.logError ?? console.error;
+    logError('[michaelzick.com] failed to sync HubSpot subscriber', error);
+    return { status: 'error', error: getHubSpotErrorMessage(error) };
+  }
+}

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -7,6 +7,16 @@ import {
   validateContactSubmission,
 } from '../lib/server/contact';
 import {
+  getHubSpotSubscriberConfig,
+  HUBSPOT_EXISTING_ENTRY_NOTE,
+  HUBSPOT_FIRST_ENTRY_NOTE,
+  HubSpotSubscriberSyncError,
+  normalizeHubSpotSubscriberInput,
+  syncHubSpotSubscriber,
+  syncHubSpotSubscriberSafely,
+  validateHubSpotSubscriberInput,
+} from '../lib/server/hubspot-subscriber';
+import {
   buildNguCouponNotificationEmail,
   buildNguCouponVisitorEmail,
   getNguCouponConfig,
@@ -18,6 +28,58 @@ import {
 } from '../lib/server/ngu-coupon';
 import { getServerOpenAIClient } from '../lib/server/openai';
 import { consumeRateLimit } from '../lib/server/rate-limit';
+
+type HubSpotFetchStubResponse = {
+  status?: number;
+  body?: unknown;
+};
+
+type HubSpotFetchRequest = {
+  url: string;
+  method?: string;
+  authorization?: string;
+  body: unknown;
+};
+
+function createHubSpotEnv(overrides: Record<string, string | undefined> = {}) {
+  return {
+    NODE_ENV: 'test',
+    HUBSPOT_SERVICE_KEY: 'service-token',
+    HUBSPOT_CONTACT_OWNER_ID: '51639144',
+    ...overrides,
+  } as unknown as NodeJS.ProcessEnv;
+}
+
+function createHubSpotFetchStub(responses: HubSpotFetchStubResponse[]) {
+  const queuedResponses = [...responses];
+  const requests: HubSpotFetchRequest[] = [];
+  const fetchFn = (async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1],
+  ) => {
+    const headers = init?.headers as Record<string, string> | undefined;
+    const rawBody = init?.body;
+    const body = typeof rawBody === 'string' ? JSON.parse(rawBody) : rawBody;
+    requests.push({
+      url: String(input),
+      method: init?.method,
+      authorization: headers?.Authorization,
+      body,
+    });
+
+    const response = queuedResponses.shift();
+    if (!response) {
+      throw new Error(`Unexpected HubSpot request: ${String(input)}`);
+    }
+
+    return new Response(response.body === undefined ? '' : JSON.stringify(response.body), {
+      status: response.status ?? 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  return { fetchFn, requests };
+}
 
 test('consumeRateLimit blocks after the configured maximum and resets after the window', () => {
   const store = new Map<string, { count: number; lastReset: number; }>();
@@ -182,6 +244,298 @@ test('NGU coupon config and recaptcha helpers validate expected state', () => {
   assert.equal(
     isValidNguRecaptchaResponse({ success: false, 'error-codes': ['invalid-input-response'] }).valid,
     false,
+  );
+});
+
+test('HubSpot subscriber config uses token fallback order and required owner', () => {
+  assert.deepEqual(
+    getHubSpotSubscriberConfig(createHubSpotEnv({
+      HUBSPOT_SERVICE_KEY: ' service ',
+      HUBSPOT_ACCESS_TOKEN: 'access',
+      HUBSPOT_PRIVATE_APP_TOKEN: 'private',
+    })),
+    {
+      accessToken: 'service',
+      ownerId: '51639144',
+    },
+  );
+
+  assert.deepEqual(
+    getHubSpotSubscriberConfig({
+      HUBSPOT_ACCESS_TOKEN: ' access ',
+      HUBSPOT_PRIVATE_APP_TOKEN: 'private',
+      HUBSPOT_CONTACT_OWNER_ID: ' owner ',
+    } as unknown as NodeJS.ProcessEnv),
+    {
+      accessToken: 'access',
+      ownerId: 'owner',
+    },
+  );
+
+  assert.deepEqual(
+    getHubSpotSubscriberConfig({
+      HUBSPOT_PRIVATE_APP_TOKEN: ' private ',
+      HUBSPOT_CONTACT_OWNER_ID: ' owner ',
+    } as unknown as NodeJS.ProcessEnv),
+    {
+      accessToken: 'private',
+      ownerId: 'owner',
+    },
+  );
+
+  assert.equal(
+    getHubSpotSubscriberConfig({
+      HUBSPOT_SERVICE_KEY: 'service',
+    } as unknown as NodeJS.ProcessEnv),
+    null,
+  );
+});
+
+test('HubSpot subscriber helpers normalize and validate input', () => {
+  assert.deepEqual(
+    normalizeHubSpotSubscriberInput({
+      email: ' Person@Example.COM ',
+      firstName: ' Michael ',
+      lastName: ' ',
+    }),
+    {
+      email: 'person@example.com',
+      firstName: 'Michael',
+      lastName: undefined,
+    },
+  );
+
+  assert.equal(
+    validateHubSpotSubscriberInput({ email: '' }),
+    'Subscriber email is required.',
+  );
+  assert.equal(
+    validateHubSpotSubscriberInput({ email: 'not-an-email' }),
+    'Subscriber email must be valid.',
+  );
+  assert.equal(
+    validateHubSpotSubscriberInput({ email: 'person@example.com', firstName: 'x'.repeat(51) }),
+    'Subscriber name fields exceed character limits.',
+  );
+  assert.equal(
+    validateHubSpotSubscriberInput({ email: 'person@example.com' }),
+    null,
+  );
+});
+
+test('HubSpot subscriber safe sync reports missing configuration without throwing', async () => {
+  let logCount = 0;
+  const result = await syncHubSpotSubscriberSafely(
+    { email: 'person@example.com' },
+    {
+      env: {} as NodeJS.ProcessEnv,
+      logError: () => {
+        logCount += 1;
+      },
+    },
+  );
+
+  assert.deepEqual(result, {
+    status: 'error',
+    error: 'HubSpot subscriber sync is not configured.',
+  });
+  assert.equal(logCount, 1);
+});
+
+test('HubSpot subscriber sync creates email-only coupon contacts without placeholder names', async () => {
+  const fetchStub = createHubSpotFetchStub([
+    { body: { results: [] } },
+    { body: { id: '202' } },
+    { body: { results: [] } },
+    { body: { id: '902' } },
+    { body: {} },
+  ]);
+
+  const result = await syncHubSpotSubscriber(
+    { email: ' Coupon.Student@Example.COM ' },
+    {
+      env: createHubSpotEnv(),
+      fetch: fetchStub.fetchFn,
+      now: () => new Date('2026-05-26T12:00:00.000Z'),
+    },
+  );
+
+  assert.deepEqual(result, {
+    contactId: '202',
+    wasExistingContact: false,
+    noteBody: HUBSPOT_FIRST_ENTRY_NOTE,
+    noteCreated: true,
+  });
+
+  const [searchRequest, createRequest, notesAssociationRequest, noteRequest, associationRequest] =
+    fetchStub.requests;
+
+  assert.equal(searchRequest.method, 'POST');
+  assert.equal(searchRequest.authorization, 'Bearer service-token');
+  const searchBody = searchRequest.body as {
+    filterGroups: Array<{ filters: Array<{ value: string }> }>;
+  };
+  assert.equal(searchBody.filterGroups[0].filters[0].value, 'coupon.student@example.com');
+
+  assert.equal(createRequest.method, 'POST');
+  assert.ok(createRequest.url.endsWith('/crm/v3/objects/contacts'));
+  const createBody = createRequest.body as { properties: Record<string, string> };
+  assert.equal(createBody.properties.email, 'coupon.student@example.com');
+  assert.equal(createBody.properties.gender, 'Male');
+  assert.equal(createBody.properties.lifecyclestage, 'subscriber');
+  assert.equal(createBody.properties.hubspot_owner_id, '51639144');
+  assert.equal('firstname' in createBody.properties, false);
+  assert.equal('lastname' in createBody.properties, false);
+
+  assert.equal(notesAssociationRequest.method, 'GET');
+  assert.ok(
+    notesAssociationRequest.url.endsWith('/crm/v4/objects/contact/202/associations/notes?limit=100'),
+  );
+
+  assert.equal(noteRequest.method, 'POST');
+  const noteBody = noteRequest.body as { properties: Record<string, string> };
+  assert.equal(noteBody.properties.hs_note_body, HUBSPOT_FIRST_ENTRY_NOTE);
+  assert.equal(noteBody.properties.hs_timestamp, '2026-05-26T12:00:00.000Z');
+
+  assert.equal(associationRequest.method, 'PUT');
+  assert.ok(
+    associationRequest.url.endsWith('/crm/v3/objects/notes/902/associations/contact/202/202'),
+  );
+});
+
+test('HubSpot subscriber sync updates contact opt-ins with supplied names', async () => {
+  const fetchStub = createHubSpotFetchStub([
+    { body: { results: [{ id: '101' }] } },
+    { body: { id: '101' } },
+    { body: { results: [] } },
+    { body: { id: '901' } },
+    { body: {} },
+  ]);
+
+  const result = await syncHubSpotSubscriber(
+    {
+      email: 'person@example.com',
+      firstName: 'Michael',
+      lastName: 'Zick',
+    },
+    {
+      env: createHubSpotEnv(),
+      fetch: fetchStub.fetchFn,
+      now: () => new Date('2026-05-26T12:00:00.000Z'),
+    },
+  );
+
+  assert.deepEqual(result, {
+    contactId: '101',
+    wasExistingContact: true,
+    noteBody: HUBSPOT_EXISTING_ENTRY_NOTE,
+    noteCreated: true,
+  });
+
+  const updateRequest = fetchStub.requests[1];
+  assert.equal(updateRequest.method, 'PATCH');
+  assert.ok(updateRequest.url.endsWith('/crm/v3/objects/contacts/101'));
+  const updateBody = updateRequest.body as { properties: Record<string, string> };
+  assert.equal(updateBody.properties.firstname, 'Michael');
+  assert.equal(updateBody.properties.lastname, 'Zick');
+  assert.equal(updateBody.properties.gender, 'Male');
+  assert.equal(updateBody.properties.lifecyclestage, 'subscriber');
+
+  const noteRequest = fetchStub.requests[3];
+  const noteBody = noteRequest.body as { properties: Record<string, string> };
+  assert.equal(noteBody.properties.hs_note_body, HUBSPOT_EXISTING_ENTRY_NOTE);
+});
+
+test('HubSpot subscriber sync retries create conflicts as existing contacts', async () => {
+  const fetchStub = createHubSpotFetchStub([
+    { body: { results: [] } },
+    { status: 409, body: { message: 'Contact already exists' } },
+    { body: { results: [{ id: '303' }] } },
+    { body: { id: '303' } },
+    { body: { results: [] } },
+    { body: { id: '903' } },
+    { body: {} },
+  ]);
+
+  const result = await syncHubSpotSubscriber(
+    { email: 'person@example.com' },
+    {
+      env: createHubSpotEnv(),
+      fetch: fetchStub.fetchFn,
+      now: () => new Date('2026-05-26T12:00:00.000Z'),
+    },
+  );
+
+  assert.deepEqual(result, {
+    contactId: '303',
+    wasExistingContact: true,
+    noteBody: HUBSPOT_EXISTING_ENTRY_NOTE,
+    noteCreated: true,
+  });
+  assert.equal(fetchStub.requests[3].method, 'PATCH');
+  assert.ok(fetchStub.requests[3].url.endsWith('/crm/v3/objects/contacts/303'));
+});
+
+test('HubSpot subscriber sync skips duplicate michaelzick.com entry notes', async () => {
+  const fetchStub = createHubSpotFetchStub([
+    { body: { results: [{ id: '404' }] } },
+    { body: { id: '404' } },
+    { body: { results: [{ toObjectId: '904' }] } },
+    {
+      body: {
+        results: [
+          {
+            id: '904',
+            properties: {
+              hs_note_body: HUBSPOT_FIRST_ENTRY_NOTE,
+            },
+          },
+        ],
+      },
+    },
+  ]);
+
+  const result = await syncHubSpotSubscriber(
+    { email: 'person@example.com' },
+    {
+      env: createHubSpotEnv(),
+      fetch: fetchStub.fetchFn,
+      now: () => new Date('2026-05-26T12:00:00.000Z'),
+    },
+  );
+
+  assert.deepEqual(result, {
+    contactId: '404',
+    wasExistingContact: true,
+    noteBody: HUBSPOT_EXISTING_ENTRY_NOTE,
+    noteCreated: false,
+  });
+  assert.equal(fetchStub.requests.length, 4);
+  assert.equal(fetchStub.requests[3].method, 'POST');
+  assert.ok(fetchStub.requests[3].url.endsWith('/crm/v3/objects/notes/batch/read'));
+});
+
+test('HubSpot subscriber sync returns sanitized dependency errors', async () => {
+  const fetchStub = createHubSpotFetchStub([
+    { status: 500, body: { message: 'token service-token exploded' } },
+  ]);
+
+  await assert.rejects(
+    syncHubSpotSubscriber(
+      { email: 'person@example.com' },
+      {
+        env: createHubSpotEnv(),
+        fetch: fetchStub.fetchFn,
+        now: () => new Date('2026-05-26T12:00:00.000Z'),
+      },
+    ),
+    (error) => {
+      assert.ok(error instanceof HubSpotSubscriberSyncError);
+      assert.equal(error.status, 502);
+      assert.equal(error.message, 'Unable to sync HubSpot subscriber.');
+      assert.equal(error.message.includes('service-token'), false);
+      return true;
+    },
   );
 });
 


### PR DESCRIPTION
## Summary

Adds HubSpot subscriber sync to the existing michaelzick.com newsletter and NGU coupon flows. NGU coupon signups still send the coupon email first, and contact-form workbook/newsletter opt-ins still send the contact notification first; HubSpot sync runs afterward as a best-effort integration so CRM issues do not block successful form submissions.

- **HubSpot male subscriber sync**: upserts contacts by normalized email with `gender = Male`, `lifecyclestage = subscriber`, and the configured HubSpot owner.
- **Email-only coupon behavior**: NGU coupon signups add/update HubSpot contacts without placeholder names or clearing existing first/last names.
- **Contact opt-in behavior**: contact-form submissions add first/last names to HubSpot only when the workbook/newsletter checkbox is selected.
- **michaelzick.com entry notes**: creates `First entry: michaelzick.com` for new contacts and `Existing entry: michaelzick.com` for existing contacts, skipping duplicate entry notes.
- **Non-blocking CRM failures**: missing HubSpot env vars or HubSpot API failures are logged with sanitized errors and do not prevent coupon/contact success responses.

## Changes

- `hubspot-subscriber.ts` (new) — server-only HubSpot config, contact upsert, note association, duplicate-note detection, sanitized error handling
- `ngu-coupon/route.ts` — syncs coupon subscribers to HubSpot after visitor/admin emails send
- `contact/route.ts` — syncs HubSpot only for workbook/newsletter opt-ins, preserving normal contact form behavior
- `server.test.ts` — adds coverage for env fallback, normalization, contact create/update, conflict retry, duplicate-note skipping, sanitized failures, and name/no-name request bodies
- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` — documents HubSpot env vars and subscriber-sync behavior

## Test plan

- [x] `npm test`
- [x] `npm run agent-briefs:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run check`

Created by Codex
